### PR TITLE
Add offline unit tests for URL parsing and mod filename helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 venv
 mods
 .python-version
+__pycache__/
+*.py[cod]

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,64 @@
+"""Unit tests for main.py helpers (stdlib only, no network)."""
+
+import os
+import tempfile
+import unittest
+
+import main
+
+
+class TestExtractCollectionId(unittest.TestCase):
+    def test_plain_id(self):
+        self.assertEqual(main.extract_collection_id("5OBQuutT"), "5OBQuutT")
+
+    def test_https_url(self):
+        self.assertEqual(
+            main.extract_collection_id(
+                "https://modrinth.com/collection/5OBQuutT"
+            ),
+            "5OBQuutT",
+        )
+
+    def test_http_www_url(self):
+        self.assertEqual(
+            main.extract_collection_id(
+                "http://www.modrinth.com/collection/abc123?foo=1"
+            ),
+            "abc123",
+        )
+
+    def test_strips_whitespace(self):
+        self.assertEqual(main.extract_collection_id("  xyz  "), "xyz")
+
+
+class TestValidateDirectory(unittest.TestCase):
+    def test_creates_missing_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "nested", "mods")
+            self.assertTrue(main.validate_directory(path))
+            self.assertTrue(os.path.isdir(path))
+
+    def test_rejects_file_path(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            path = f.name
+        try:
+            self.assertFalse(main.validate_directory(path))
+        finally:
+            os.unlink(path)
+
+
+class TestGetExistingMods(unittest.TestCase):
+    def test_parses_mod_id_from_filename(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            open(os.path.join(tmp, "foo-bar.LQ3K71Q1.jar"), "w").close()
+            mods = main.get_existing_mods(tmp)
+            self.assertIn("LQ3K71Q1", mods)
+            self.assertEqual(mods["LQ3K71Q1"]["filename"], "foo-bar.LQ3K71Q1.jar")
+
+    def test_empty_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(main.get_existing_mods(tmp), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small `unittest` suite (`test_main.py`) that exercises pure helpers in `main.py` without network access: `extract_collection_id`, `validate_directory`, and `get_existing_mods`.

Also updates `.gitignore` to exclude `__pycache__/` and `*.py[cod]` so local test runs do not leave untracked bytecode.

## How to verify

```bash
python3 -m unittest test_main.py -v
```

## Context

This supports ongoing validation of the downloader script and gives a quick regression check for collection URL parsing and existing-mod detection.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c05f7dd-6fab-4a91-910f-bf178bdb93f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c05f7dd-6fab-4a91-910f-bf178bdb93f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

