### PR TITLE
Install resource packs into resourcepacks folder

### DIFF
--- a/main.py
+++ b/main.py
@@ -155,6 +155,15 @@ def parse_args():
     return args
 
 
+def resourcepacks_directory(mods_directory: str) -> str:
+    """Return the standard sibling `resourcepacks` folder for a given mods directory.
+
+    Example: ``./mods`` -> ``./resourcepacks``; ``/instance/mods`` -> ``/instance/resourcepacks``.
+    """
+    parent = os.path.dirname(os.path.abspath(mods_directory))
+    return os.path.join(parent, "resourcepacks")
+
+
 def validate_directory(directory: str) -> bool:
     """Validate that the directory path is valid and create if needed.
     
@@ -176,12 +185,14 @@ def validate_directory(directory: str) -> bool:
 def get_existing_mods(directory: str) -> Dict[str, Dict[str, str]]:
     """Get existing mods from the directory.
     
-    Returns a dictionary mapping mod_id to mod info dict.
+    Returns a dictionary mapping mod_id to mod info dict with keys:
+    ``id``, ``filename``, and ``directory`` (absolute path where the file lives).
     Handles edge cases like files without extensions or unusual names.
     """
     if not os.path.exists(directory):
         return {}
     
+    abs_dir = os.path.abspath(directory)
     existing_mods: Dict[str, Dict[str, str]] = {}
     try:
         for item in os.listdir(directory):
@@ -196,7 +207,11 @@ def get_existing_mods(directory: str) -> Dict[str, Dict[str, str]]:
             if len(parts) >= 2:
                 # Has at least one dot, mod_id should be second-to-last part
                 mod_id = parts[-2]
-                existing_mods[mod_id] = {"id": mod_id, "filename": item}
+                existing_mods[mod_id] = {
+                    "id": mod_id,
+                    "filename": item,
+                    "directory": abs_dir,
+                }
             else:
                 # No extension, skip or handle differently
                 # For now, we'll skip files without proper format
@@ -207,17 +222,47 @@ def get_existing_mods(directory: str) -> Dict[str, Dict[str, str]]:
     return existing_mods
 
 
-def get_mod_name(modrinth_client: ModrinthClient, mod_id: str) -> str:
+def merge_existing_mods(
+    mods_directory: str, resourcepacks_directory: str
+) -> Dict[str, Dict[str, str]]:
+    """Index files in both ``mods`` and ``resourcepacks`` for skip/update logic."""
+    merged = dict(get_existing_mods(mods_directory))
+    for mod_id, info in get_existing_mods(resourcepacks_directory).items():
+        merged[mod_id] = info
+    return merged
+
+
+def get_mod_name(
+    modrinth_client: ModrinthClient,
+    mod_id: str,
+    project_data: Optional[dict] = None,
+) -> str:
     """Get the mod name (title or slug) for display purposes."""
-    project_data = modrinth_client.get_mod_project(mod_id)
-    if project_data:
-        # Prefer title, fallback to slug, fallback to mod_id
-        return project_data.get("title") or project_data.get("slug") or mod_id
+    data = project_data if project_data is not None else modrinth_client.get_mod_project(mod_id)
+    if data:
+        return data.get("title") or data.get("slug") or mod_id
     return mod_id
 
 
+def _version_matches_loader(
+    mod_version: dict, loader: str, project_type: str
+) -> bool:
+    """Whether a version's loaders satisfy the requested loader filter."""
+    loaders = mod_version.get("loaders", [])
+    if loader in loaders:
+        return True
+    # Modrinth marks resource pack versions with loader ``minecraft`` only.
+    if project_type == "resourcepack" and "minecraft" in loaders:
+        return True
+    return False
+
+
 def get_latest_version(
-    modrinth_client: ModrinthClient, mod_id: str, version: str, loader: str
+    modrinth_client: ModrinthClient,
+    mod_id: str,
+    version: str,
+    loader: str,
+    project_type: str = "mod",
 ) -> Optional[dict]:
     """Get the latest version of a mod matching the specified version and loader."""
     mod_versions_data = modrinth_client.get_mod_version(mod_id)
@@ -229,7 +274,7 @@ def get_latest_version(
             mod_version
             for mod_version in mod_versions_data
             if version in mod_version.get("game_versions", [])
-            and loader in mod_version.get("loaders", [])
+            and _version_matches_loader(mod_version, loader, project_type)
         ),
         None,
     )
@@ -239,7 +284,7 @@ def get_latest_version(
 def download_mod(
     mod_id: str,
     modrinth_client: ModrinthClient,
-    directory: str,
+    mods_directory: str,
     version: str,
     loader: str,
     update: bool,
@@ -272,13 +317,24 @@ def download_mod(
     # Prefix for dependency logging
     dep_prefix = "  [DEPENDENCY] " if is_dependency else ""
     
+    project_data: Optional[dict] = None
     try:
+        project_data = modrinth_client.get_mod_project(mod_id)
+        project_type = (project_data or {}).get("project_type", "mod")
+        target_directory = (
+            resourcepacks_directory(mods_directory)
+            if project_type == "resourcepack" and not is_dependency
+            else mods_directory
+        )
+        if not validate_directory(target_directory):
+            return
+
         existing_mod = existing_mods.get(mod_id)
 
         # Early skip - no need to fetch mod name
         if not update and existing_mod:
             if is_dependency:
-                mod_name = get_mod_name(modrinth_client, mod_id)
+                mod_name = get_mod_name(modrinth_client, mod_id, project_data)
                 mod_display = f"{mod_name} ({mod_id})" if mod_name != mod_id else mod_id
                 print(f"{dep_prefix}SKIP: {mod_display} already exists (use -u/--update to update)")
             else:
@@ -289,22 +345,35 @@ def download_mod(
             else:
                 stats["main_skipped"] = stats.get("main_skipped", 0) + 1
             # Still process dependencies even if mod is skipped
-            latest_mod = get_latest_version(modrinth_client, mod_id, version, loader)
+            latest_mod = get_latest_version(
+                modrinth_client, mod_id, version, loader, project_type
+            )
             if latest_mod:
                 _process_dependencies(
-                    latest_mod, modrinth_client, directory, version, loader,
-                    update, existing_mods, stats, failed_mods, processed_mods, mod_id
+                    latest_mod,
+                    modrinth_client,
+                    mods_directory,
+                    version,
+                    loader,
+                    update,
+                    existing_mods,
+                    stats,
+                    failed_mods,
+                    processed_mods,
+                    mod_id,
                 )
             return
 
-        latest_mod = get_latest_version(modrinth_client, mod_id, version, loader)
+        latest_mod = get_latest_version(
+            modrinth_client, mod_id, version, loader, project_type
+        )
         # import json
         # print("=" * 50)
         # print(f"existing_mod: {existing_mod}, latest_mod: {json.dumps(latest_mod)}")
         # print("=" * 50)
         if not latest_mod:
             # Error case - fetch mod name for better error message
-            mod_name = get_mod_name(modrinth_client, mod_id)
+            mod_name = get_mod_name(modrinth_client, mod_id, project_data)
             mod_display = f"{mod_name} ({mod_id})" if mod_name != mod_id else mod_id
             error_msg = f"{dep_prefix}ERROR: No version found for {mod_display} with MC_VERSION={version} and LOADER={loader}"
             if is_dependency and parent_mod_id:
@@ -323,13 +392,22 @@ def download_mod(
             dependencies = latest_mod.get("dependencies", [])
             required_deps = [dep for dep in dependencies if dep.get("dependency_type") == "required"]
             if required_deps:
-                mod_name = get_mod_name(modrinth_client, mod_id)
+                mod_name = get_mod_name(modrinth_client, mod_id, project_data)
                 mod_display = f"{mod_name} ({mod_id})" if mod_name != mod_id else mod_id
                 print(f"Processing {len(required_deps)} required dependency(ies) for {mod_display}...")
         
         _process_dependencies(
-            latest_mod, modrinth_client, directory, version, loader,
-            update, existing_mods, stats, failed_mods, processed_mods, mod_id
+            latest_mod,
+            modrinth_client,
+            mods_directory,
+            version,
+            loader,
+            update,
+            existing_mods,
+            stats,
+            failed_mods,
+            processed_mods,
+            mod_id,
         )
 
         # Find primary file
@@ -338,7 +416,7 @@ def download_mod(
         )
         if not file_to_download:
             # Error case - fetch mod name for better error message
-            mod_name = get_mod_name(modrinth_client, mod_id)
+            mod_name = get_mod_name(modrinth_client, mod_id, project_data)
             mod_display = f"{mod_name} ({mod_id})" if mod_name != mod_id else mod_id
             print(f"{dep_prefix}ERROR: Couldn't find a primary file to download for {mod_display}")
             stats["failed"] += 1
@@ -353,12 +431,12 @@ def download_mod(
         filename_parts = filename.split(".")
         filename_parts.insert(-1, mod_id)
         filename_with_id = ".".join(filename_parts)
-        file_path = os.path.join(directory, filename_with_id)
+        file_path = os.path.join(target_directory, filename_with_id)
 
         # Skip if already at latest version - check both existing_mods dict and disk
         if existing_mod and existing_mod["filename"] == filename_with_id:
             if is_dependency:
-                mod_name = get_mod_name(modrinth_client, mod_id)
+                mod_name = get_mod_name(modrinth_client, mod_id, project_data)
                 mod_display = f"{mod_name} ({mod_id})" if mod_name != mod_id else mod_id
                 print(f"{dep_prefix}SKIP: {mod_display} ({filename_with_id}) latest version already exists")
             else:
@@ -374,7 +452,7 @@ def download_mod(
         # Only skip if it's the exact same version and we're not in update mode
         if os.path.exists(file_path) and not update:
             if is_dependency:
-                mod_name = get_mod_name(modrinth_client, mod_id)
+                mod_name = get_mod_name(modrinth_client, mod_id, project_data)
                 mod_display = f"{mod_name} ({mod_id})" if mod_name != mod_id else mod_id
                 print(f"{dep_prefix}SKIP: {mod_display} ({filename_with_id}) already exists on disk")
             else:
@@ -387,7 +465,7 @@ def download_mod(
             return
 
         # We're actually downloading/updating - fetch mod name for display
-        mod_name = get_mod_name(modrinth_client, mod_id)
+        mod_name = get_mod_name(modrinth_client, mod_id, project_data)
         mod_display = f"{mod_name} ({mod_id})" if mod_name != mod_id else mod_id
         action = "UPDATING" if existing_mod else "DOWNLOADING"
         loaders_str = ", ".join(latest_mod.get("loaders", []))
@@ -422,7 +500,8 @@ def download_mod(
 
         # Only remove old file if download succeeded
         if existing_mod:
-            old_file_path = os.path.join(directory, existing_mod["filename"])
+            old_dir = existing_mod.get("directory") or target_directory
+            old_file_path = os.path.join(old_dir, existing_mod["filename"])
             try:
                 if os.path.exists(old_file_path):
                     os.remove(old_file_path)
@@ -442,10 +521,16 @@ def download_mod(
             else:
                 stats["main_updated"] = stats.get("main_updated", 0) + 1
 
+        existing_mods[mod_id] = {
+            "id": mod_id,
+            "filename": filename_with_id,
+            "directory": os.path.abspath(target_directory),
+        }
+
     except Exception as e:
         # Error case - fetch mod name for better error message
         try:
-            mod_name = get_mod_name(modrinth_client, mod_id)
+            mod_name = get_mod_name(modrinth_client, mod_id, project_data)
             error_mod_display = f"{mod_name} ({mod_id})" if mod_name != mod_id else mod_id
         except:
             error_mod_display = mod_id
@@ -461,7 +546,7 @@ def download_mod(
 def _process_dependencies(
     latest_mod: dict,
     modrinth_client: ModrinthClient,
-    directory: str,
+    mods_directory: str,
     version: str,
     loader: str,
     update: bool,
@@ -496,7 +581,7 @@ def _process_dependencies(
         download_mod(
             dep_project_id,
             modrinth_client,
-            directory,
+            mods_directory,
             version,
             loader,
             update,
@@ -515,6 +600,9 @@ def main():
 
     # Validate and create directory
     if not validate_directory(args.directory):
+        return
+    rp_dir = resourcepacks_directory(args.directory)
+    if not validate_directory(rp_dir):
         return
 
     # Validate required inputs (should not be empty after prompting)
@@ -536,7 +624,7 @@ def main():
         return
 
     print(f"Found {len(mods)} mod(s) in collection")
-    existing_mods = get_existing_mods(args.directory)
+    existing_mods = merge_existing_mods(args.directory, rp_dir)
 
     # Statistics tracking
     stats = {

--- a/test_main.py
+++ b/test_main.py
@@ -54,10 +54,68 @@ class TestGetExistingMods(unittest.TestCase):
             mods = main.get_existing_mods(tmp)
             self.assertIn("LQ3K71Q1", mods)
             self.assertEqual(mods["LQ3K71Q1"]["filename"], "foo-bar.LQ3K71Q1.jar")
+            self.assertEqual(
+                mods["LQ3K71Q1"]["directory"], os.path.abspath(tmp)
+            )
 
     def test_empty_directory(self):
         with tempfile.TemporaryDirectory() as tmp:
             self.assertEqual(main.get_existing_mods(tmp), {})
+
+
+class TestResourcepacksDirectory(unittest.TestCase):
+    def test_sibling_of_mods(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mods_path = os.path.join(tmp, "mods")
+            rp = main.resourcepacks_directory(mods_path)
+            self.assertEqual(rp, os.path.join(tmp, "resourcepacks"))
+
+
+class TestMergeExistingMods(unittest.TestCase):
+    def test_resourcepacks_wins_on_duplicate_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mods_path = os.path.join(tmp, "mods")
+            rp_path = os.path.join(tmp, "resourcepacks")
+            os.makedirs(mods_path)
+            os.makedirs(rp_path)
+            open(os.path.join(mods_path, "old.ABCD1234.zip"), "w").close()
+            open(os.path.join(rp_path, "new.ABCD1234.zip"), "w").close()
+            merged = main.merge_existing_mods(mods_path, rp_path)
+            self.assertEqual(merged["ABCD1234"]["filename"], "new.ABCD1234.zip")
+            self.assertEqual(merged["ABCD1234"]["directory"], os.path.abspath(rp_path))
+
+
+class TestGetLatestVersionLoaderMatching(unittest.TestCase):
+    class _FakeClient:
+        def __init__(self, versions):
+            self._versions = versions
+
+        def get_mod_version(self, mod_id):
+            return self._versions
+
+    def test_resourcepack_matches_minecraft_loader_when_user_loader_fabric(self):
+        versions = [
+            {
+                "game_versions": ["1.21"],
+                "loaders": ["minecraft"],
+            }
+        ]
+        client = self._FakeClient(versions)
+        got = main.get_latest_version(
+            client, "x", "1.21", "fabric", "resourcepack"
+        )
+        self.assertIsNotNone(got)
+
+    def test_mod_requires_explicit_loader_match(self):
+        versions = [
+            {
+                "game_versions": ["1.21"],
+                "loaders": ["minecraft"],
+            }
+        ]
+        client = self._FakeClient(versions)
+        got = main.get_latest_version(client, "x", "1.21", "fabric", "mod")
+        self.assertIsNone(got)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This addresses the request to stop colocating Modrinth **resource packs** in the `mods` folder. Projects whose Modrinth `project_type` is `resourcepack` now have their primary file saved under a sibling **`resourcepacks`** directory (same parent as the configured mods path, e.g. `./mods` → `./resourcepacks`).

## Behavior

- **Resource pack projects**: primary download goes to `resourcepacks/`; required dependencies still go to the mods directory (typical mods/libraries).
- **Loader filter**: resource pack versions often only list the `minecraft` loader on Modrinth; those versions are now considered a match when the user passes another loader (e.g. `fabric`), so you do not need a separate run with loader `minecraft` for packs in a mixed collection.
- **Updates / skips**: existing files are indexed from both `mods` and `resourcepacks` so re-runs detect installed packs and can remove the previous file from the correct folder when updating.

## Tests

- Added unit tests for directory resolution, merge precedence, and loader matching for resource packs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95e97f61-cdff-43f8-9492-ee1f802b4d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95e97f61-cdff-43f8-9492-ee1f802b4d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

